### PR TITLE
fix: 🐛 画像ファイルの URL の戻り値を原寸大画像が落とせる URL に修正した

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -326,11 +326,16 @@ pry> ByListTweet.find_by(id_number: 719421755110993920).list
 
 ```ruby
 target_list = List.find_(name: 'FOOBAR')
-media_urls = target_list.tweets.map {|tweet| tweet.array_of_media_urls }
+media_urls = target_list.tweets.map { |tweet| tweet.array_of_media_urls }
 media_urls.flatten!
 
 media_urls.each do |media_url|
-  command = "wget #{media_url}"
+  # media_url: https://pbs.twimg.com/media/FAlJ_JsUUAAgOSq?format=jpg&name=orig
+  # filename_without_extension: FAlJ_JsUUAAgOSq
+  # extension_without_dot: jpg
+  filename_without_extension = File.basename(/\A(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?\Z/.match(media_url)[5])
+  extension_without_dot = /\A.*\?format=(.*)&name=orig\Z/.match(media_url)[1]
+  command = "wget -nc '#{media_url}' -O #{filename_without_extension}.#{extension_without_dot}"
   `#{command}`
 end
 ```

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -138,8 +138,14 @@ class Tweet < ApplicationRecord
 
   def array_of_media_urls
     media.map do |medium|
-      # The default parameter is 'name=orig'
-      medium.media_url_https.to_s
+      # media_url_https: https://pbs.twimg.com/media/FAlJ_JsUUAAgOSq.jpg
+      # 原寸大URL: https://pbs.twimg.com/media/FAlJ_JsUUAAgOSq?format=jpg&name=orig
+      url = medium.media_url_https.to_s
+      extension_including_dot = File.extname(url)
+      extension_without_dot = extension_including_dot[1..]
+      url_without_extension = url.gsub(extension_including_dot, '')
+
+      "#{url_without_extension}?format=#{extension_without_dot}&name=orig"
     end
   end
 


### PR DESCRIPTION
- `https://pbs.twimg.com/media/FAlJ_JsUUAAgOSq.jpg`

ではなく、

- `https://pbs.twimg.com/media/FAlJ_JsUUAAgOSq?format=jpg&name=orig`

でないといけない。