### PR TITLE
Gemfile 内の Ruby のバージョンを v3.1 にし、gem の不備に対応した

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:3.0.3
-      - image: circleci/postgres:13.5
+      - image: cimg/ruby:3.1.0
+      - image: cimg/postgres:13.5
         environment:
           - POSTGRES_USER: tweet_storage
           - POSTGRES_PASSWORD: tweet_storage

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -5,7 +5,7 @@ jobs:
     name: Tweet Storage CI
     runs-on: ubuntu-latest
     container:
-      image: ruby:3.0.3
+      image: ruby:3.1.0
       env:
         BUNDLE_PATH: vendor/bundle
     services:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.3'
+ruby '3.1.0'
 
 gem 'bootsnap', require: false
 gem 'dotenv-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gem 'dotenv-rails'
 gem 'google_drive'
 gem 'pg'
 gem 'pry-rails'
-gem 'rails'
+# https://github.com/rails/rails/issues/43998
+gem 'rails', git: 'https://github.com/rails/rails', branch: '7-0-stable'
 gem 'sprockets-rails'
 gem 'twitter'
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '3.1.0'
 gem 'bootsnap', require: false
 gem 'dotenv-rails'
 gem 'google_drive'
+gem 'net-smtp', require: false
 gem 'pg'
 gem 'pry-rails'
 # https://github.com/rails/rails/issues/43998

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ DEPENDENCIES
   twitter
 
 RUBY VERSION
-   ruby 3.0.3p157
+   ruby 3.1.0p0
 
 BUNDLED WITH
    2.2.32

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     crass (1.0.6)
     declarative (0.0.20)
     diff-lcs (1.4.4)
+    digest (3.1.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
@@ -177,6 +178,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    io-wait (0.2.1)
     jwt (2.3.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -198,6 +200,13 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.1.1)
     naught (1.1.0)
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
@@ -289,6 +298,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.1.0)
     thread_safe (0.3.6)
+    timeout (0.2.0)
     trailblazer-option (0.1.2)
     twitter (7.0.0)
       addressable (~> 2.3)
@@ -323,6 +333,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   google_drive
+  net-smtp
   pg
   pry-rails
   rails!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/rails/rails
+  revision: c837883cfcf880ac7a96223545b0cf4fac2986e0
+  branch: 7-0-stable
   specs:
     actioncable (7.0.0)
       actionpack (= 7.0.0)
@@ -60,6 +62,31 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    rails (7.0.0)
+      actioncable (= 7.0.0)
+      actionmailbox (= 7.0.0)
+      actionmailer (= 7.0.0)
+      actionpack (= 7.0.0)
+      actiontext (= 7.0.0)
+      actionview (= 7.0.0)
+      activejob (= 7.0.0)
+      activemodel (= 7.0.0)
+      activerecord (= 7.0.0)
+      activestorage (= 7.0.0)
+      activesupport (= 7.0.0)
+      bundler (>= 1.15.0)
+      railties (= 7.0.0)
+    railties (7.0.0)
+      actionpack (= 7.0.0)
+      activesupport (= 7.0.0)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
@@ -190,32 +217,11 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (7.0.0)
-      actioncable (= 7.0.0)
-      actionmailbox (= 7.0.0)
-      actionmailer (= 7.0.0)
-      actionpack (= 7.0.0)
-      actiontext (= 7.0.0)
-      actionview (= 7.0.0)
-      activejob (= 7.0.0)
-      activemodel (= 7.0.0)
-      activerecord (= 7.0.0)
-      activestorage (= 7.0.0)
-      activesupport (= 7.0.0)
-      bundler (>= 1.15.0)
-      railties (= 7.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    railties (7.0.0)
-      actionpack (= 7.0.0)
-      activesupport (= 7.0.0)
-      method_source
-      rake (>= 12.2)
-      thor (~> 1.0)
-      zeitwerk (~> 2.5)
     rainbow (3.0.0)
     rake (13.0.6)
     rb-fsevent (0.11.0)
@@ -319,7 +325,7 @@ DEPENDENCIES
   google_drive
   pg
   pry-rails
-  rails
+  rails!
   rspec-rails
   rspec_junit_formatter
   rubocop-rails


### PR DESCRIPTION
### 1. Rails 7

```ruby
# https://github.com/rails/rails/issues/43998
gem 'rails', git: 'https://github.com/rails/rails', branch: '7-0-stable'
```

### 2. net-smtp

```ruby
gem 'net-smtp', require: false
```
